### PR TITLE
fix: voila-vuetify stalls on "Executing cell x of x"

### DIFF
--- a/share/jupyter/voila/templates/jdaviz-default/nbconvert_templates/util.js
+++ b/share/jupyter/voila/templates/jdaviz-default/nbconvert_templates/util.js
@@ -106,18 +106,11 @@ window.init = async (voila) => {
         const originalLoader = widgetManager.loader;
         widgetManager.loader = (moduleName, moduleVersion) => {
             if (moduleName === 'jupyter-vuetify' || moduleName === 'jupyter-vue') {
-                const newModuleName = moduleName + '/nodeps';
-                const promise = originalLoader(newModuleName, moduleVersion);
-                if (moduleName === 'jupyter-vue') {
-                    promise.then(_ => requirejs.config({
-                        map: {
-                            '*': {
-                                [moduleName]: newModuleName
-                            }
-                        }
-                    }));
-                }
-                return promise;
+                requirejs.config({
+                    paths: {
+                        [moduleName]: [`${moduleName}/nodeps`, `https://unpkg.com/${moduleName}@${moduleVersion}/dist/nodeps`]
+                    }
+                });
             }
             return originalLoader(moduleName, moduleVersion);
         };


### PR DESCRIPTION
Changing the requirejs mapping after the nodeps version of
jupyter-vue is loaded, is too late. Some times jupyter-vuetify is
loaded before jupyter-vue. Setting the CDN path directly before
loading solves this at the expense of duplicating the CDN URL
generation from the Voila loader.

Specifying the CDN URL as fallback for [moduleName]/nodeps is to
maintain the same behavior as the Voila loader. This allows to
load local versions of the modules for testing purposes.